### PR TITLE
Admin Schema and Register Route

### DIFF
--- a/app/controllers/admins.controller.js
+++ b/app/controllers/admins.controller.js
@@ -1,0 +1,48 @@
+var Admin = require('../models/admin.model');
+var User = require('../models/user.model');
+var AuthUtils = require('../utils/authentication.utils');
+
+exports.isAdmin = function (req, res, next) {
+    var user = AuthUtils.getUserFromToken(req);
+    Admin.findOne({ 'user': user }, function (err, admin) {
+        if (err || !admin) {
+            return res.status(401).send('unauthorized');
+        }
+        next();
+    });
+};
+
+exports.findUserByEmail = function (req, res, next) {
+    User.findOne({ 'email': req.body.email }, function (err, user) {
+        if (err || !user) {
+            return res.status(400).send('Could not find user with given email.');
+        }
+        req.new_admin_user = user;
+        next();
+    });
+};
+
+exports.doesAdminAlreadyExist = function (req, res, next) {
+    Admin.findOne({ 'user': req.new_admin_user }, function (err, found) {
+        if (found) {
+            return res.status(422).send('User is already an admin.');
+        }
+        if (err) {
+            return res.status(500).send('Failed to register user as admin.');
+        }
+        next();
+    });
+};
+
+exports.registerAdmin = function (req, res, next) {
+    var admin = new Admin({
+        user: req.new_admin_user
+    });
+    admin.save(function (err) {
+        if (err) {
+            return res.status(500).send('Failed to register user as admin.');
+        } else {
+            return res.status(201).send('User succesfully registered as admin.');
+        }
+    });
+};

--- a/app/controllers/admins.controller.js
+++ b/app/controllers/admins.controller.js
@@ -6,7 +6,7 @@ exports.isAdmin = function (req, res, next) {
     var user = AuthUtils.getUserFromToken(req);
     Admin.findOne({ 'user': user }, function (err, admin) {
         if (err || !admin) {
-            return res.status(401).send('unauthorized');
+            return res.status(403).send('forbidden');
         }
         next();
     });

--- a/app/models/admin.model.js
+++ b/app/models/admin.model.js
@@ -1,0 +1,12 @@
+var mongoose = require('mongoose');
+var Schema = mongoose.Schema;
+
+var AdminSchema = new Schema({
+    user: {
+        type: mongoose.Schema.Types.ObjectId,
+        required: true,
+        ref: 'User'
+    }
+});
+
+module.exports = mongoose.model('Admin', AdminSchema);

--- a/app/routes/admins.routes.js
+++ b/app/routes/admins.routes.js
@@ -1,0 +1,22 @@
+var admins = require('../controllers/admins.controller');
+var auth = require('../utils/auth-middleware.utils');
+
+module.exports = function (app) {
+    app.post('/admin/register',
+        auth.authenticateTokenMiddleware,
+        admins.isAdmin,
+        admins.findUserByEmail,
+        admins.doesAdminAlreadyExist,
+        admins.registerAdmin);
+
+/*
+ *  The purpose of this route is to create the very first admin
+ *  and then for this route to be deleted. After this route is
+ *  deleted, new admins can only be registered by another admin.
+ */
+    app.post('/admin/temporary-register',
+        auth.authenticateTokenMiddleware,
+        admins.findUserByEmail,
+        admins.doesAdminAlreadyExist,
+        admins.registerAdmin);
+};

--- a/app/utils/auth-middleware.utils.js
+++ b/app/utils/auth-middleware.utils.js
@@ -1,0 +1,9 @@
+var AuthUtils = require('./authentication.utils');
+
+exports.authenticateTokenMiddleware = function(req, res, next) {
+    if (AuthUtils.authenticateToken(req)) {
+        next();
+    } else {
+        return res.status(401).send('unauthorized');
+    }
+};

--- a/config/express.js
+++ b/config/express.js
@@ -25,6 +25,7 @@ module.exports = function() {
     require('../app/routes/index.routes.js')(app);
     require('../app/routes/users.routes.js')(app);
     require('../app/routes/listings.routes.js')(app);
+    require('../app/routes/admins.routes.js')(app);
 
     app.use(express.static('./public'));
 


### PR DESCRIPTION
This PR is part of the Admin Banning Users user story: https://github.com/matthewkohlhaas/GTThriftShopUI/issues/41.

In this PR I added the Admin Schema and two routes for registering an admin. One route is the permanent method for registering admins, and the other is a temporary route to create the very first admin.

Also, I added the `auth-middleware.utils.js` file that we can call from the routing files to handle authentication without having to program it into every controller method.